### PR TITLE
Feature: Add names of joints to plot.

### DIFF
--- a/mechanism/mechanism.py
+++ b/mechanism/mechanism.py
@@ -847,11 +847,17 @@ class Mechanism:
         ax.set_ylim(y_min - cushion, y_max + cushion)
 
         plot_dict = {}
+        
+        joints = {}
+        """
+        a dict to plot names of joints
+        """
         for v in self.vectors:
             if not v.pos.show:
                 continue
 
             plot_dict.update({v.pos: ax.plot([], [], **v.pos.kwargs)[0]})
+            
 
         for j in self.joints:
             if j.follow:
@@ -865,8 +871,14 @@ class Mechanism:
             text_list.append(text)
 
         def init():
-            for line in plot_dict.values():
+            for vec, line in plot_dict.items():
+                j1, j2 = vec.joints
                 line.set_data([], [])
+                if show_joint_names:
+                    xy1 = (j1.x_positions[0], j1.y_positions[0])
+                    xy2 = (j2.x_positions[0], j2.y_positions[0])
+                    joints.update({j1: plt.annotate(xy=xy1, text=j1.name)})
+                    joints.update({j2: plt.annotate(xy=xy2, text=j2.name)})
             for arrow in vel_arrow_patches:
                 arrow.set_positions(posA=(0, 0), posB=(0, 0))
             for arrow in acc_arrow_patches:
@@ -876,13 +888,15 @@ class Mechanism:
             return list(plot_dict.values()) + vel_arrow_patches + acc_arrow_patches + text_list
 
         def animate(i):
-            joints = []
+            
             for vec, line in plot_dict.items():
                 j1, j2 = vec.joints
                 line.set_data((j1.x_positions[i], j2.x_positions[i]), (j1.y_positions[i], j2.y_positions[i]))
                 if show_joint_names:
-                    joints.append(plt.text(x=j1.x_positions[i], y=j1.y_positions[i], s=j1.name))
-                    joints.append(plt.annotate(xy=(j2.x_positions[i], j2.y_positions[i]), text=j2.name))
+                    xy1 = (j1.x_positions[i], j1.y_positions[i])
+                    xy2 = (j2.x_positions[i], j2.y_positions[i])
+                    joints.update({j1: plt.annotate(xy=xy1, text=j1.name)})
+                    joints.update({j2: plt.annotate(xy=xy2, text=j2.name)})
             if velocity:
                 for joint, arrow in zip(self.joints, vel_arrow_patches):
                     x_head, y_head = np.real(joint._vel_heads)[i], np.imag(joint._vel_heads)[i]
@@ -893,7 +907,7 @@ class Mechanism:
                     arrow.set_positions(posA=(joint.x_positions[i], joint.y_positions[i]), posB=(x_head, y_head))
             if text_list:
                 text.set_text(f'{stamp[i]:.3f}')
-            return list(plot_dict.values()) + vel_arrow_patches + acc_arrow_patches + text_list + joints
+            return list(plot_dict.values()) + vel_arrow_patches + acc_arrow_patches + text_list + list(joints.values())
 
         # noinspection PyTypeChecker
         ani = Player(fig, animate, frames=self.pos.shape[0], interval=50, blit=True, init_func=init)

--- a/mechanism/mechanism.py
+++ b/mechanism/mechanism.py
@@ -789,7 +789,7 @@ class Mechanism:
         return (x_min, x_max), (y_min, y_max)
 
     def get_animation(self, velocity=False, acceleration=False, scale=0.1, stamp=None, stamp_loc=(0.05, 0.9),
-                      grid=True, cushion=1):
+                      grid=True, cushion=1, show_joint_names=False):
         """
         :param velocity: bool; Plots velocity vectors if True
         :param acceleration: bool; Plots acceleration vectors if True
@@ -802,6 +802,7 @@ class Mechanism:
                           the stamp 50% along the x direction and 75% along the y direction.
         :param grid: bool; Add the grid if true.
         :param cushion: int, float; Add a cushion around the plot.
+        :param show_joint_names: bool; Show joint' names if true.
         :return: An animation, figure, and axes object.
         """
         fig, ax = plt.subplots()
@@ -875,9 +876,13 @@ class Mechanism:
             return list(plot_dict.values()) + vel_arrow_patches + acc_arrow_patches + text_list
 
         def animate(i):
+            joints = []
             for vec, line in plot_dict.items():
                 j1, j2 = vec.joints
                 line.set_data((j1.x_positions[i], j2.x_positions[i]), (j1.y_positions[i], j2.y_positions[i]))
+                if show_joint_names:
+                    joints.append(plt.text(x=j1.x_positions[i], y=j1.y_positions[i], s=j1.name))
+                    joints.append(plt.annotate(xy=(j2.x_positions[i], j2.y_positions[i]), text=j2.name))
             if velocity:
                 for joint, arrow in zip(self.joints, vel_arrow_patches):
                     x_head, y_head = np.real(joint._vel_heads)[i], np.imag(joint._vel_heads)[i]
@@ -888,7 +893,7 @@ class Mechanism:
                     arrow.set_positions(posA=(joint.x_positions[i], joint.y_positions[i]), posB=(x_head, y_head))
             if text_list:
                 text.set_text(f'{stamp[i]:.3f}')
-            return list(plot_dict.values()) + vel_arrow_patches + acc_arrow_patches + text_list
+            return list(plot_dict.values()) + vel_arrow_patches + acc_arrow_patches + text_list + joints
 
         # noinspection PyTypeChecker
         ani = Player(fig, animate, frames=self.pos.shape[0], interval=50, blit=True, init_func=init)


### PR DESCRIPTION
Hello! I recently needed to make some calculations for a four-bar linkage and I found your package extremely useful! While using it I came up with a few more things that may  make the package even better.

I've added option `show_joint_names` to function `get_animation` in **Mechanism** class. When set to True, it adds names of each joint to the plot using [Matplotlib.axes.Axes.text](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.text.html).

It makes easier to mention specific part of a mechanism. For example it might be useful in tests like ones in folder `tests/mechanism`.

Here is an example:
![image](https://github.com/gabemorris12/mechanism/assets/51487801/10f85a77-1dd4-4434-a0f6-b7233fb031ed)


